### PR TITLE
Fixing a sign vs unsigned comparison warning

### DIFF
--- a/src/tpm_codec.c
+++ b/src/tpm_codec.c
@@ -1199,7 +1199,8 @@ TSS_BuildCommand(
         || (!handles && numHandles)
         || (!sessions && numSessions)
         || (!params && paramsSize)
-        || (!cmdBuffer || bufCapacity < STD_RESPONSE_HEADER) )
+        || (bufCapacity < 0)
+        || (!cmdBuffer || (((UINT32)bufCapacity) < STD_RESPONSE_HEADER)) )
     {
         return 0;
     }


### PR DESCRIPTION
Changes here address the following warning.

error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
         || (!cmdBuffer || bufCapacity < STD_RESPONSE_HEADER) )