### PR TITLE
Removed additional warnings 

### DIFF
--- a/src/tpm_codec.c
+++ b/src/tpm_codec.c
@@ -1169,7 +1169,9 @@ TSS_SendCommand(
 //
 TPMA_OBJECT ToTpmaObject(UINT32 attrs)
 {
-    return *(TPMA_OBJECT*)&attrs;
+    TPMA_OBJECT tpma_object;
+    memcpy(&tpma_object, &attrs, sizeof(TPMA_OBJECT));
+    return tpma_object;
 }
 
 //

--- a/src/tpm_comm_linux.c
+++ b/src/tpm_comm_linux.c
@@ -232,7 +232,7 @@ void tpm_comm_destroy(TPM_COMM_HANDLE handle)
         }
         else if (handle->conn_info & TCI_TRM)
         {
-            send_sync_cmd(handle, REMOTE_SESSION_END_CMD);
+            close_simulator(handle);
             tpm_socket_destroy(handle->dev_info.socket_conn);
         }
         free(handle);
@@ -327,8 +327,7 @@ int tpm_comm_submit_command(TPM_COMM_HANDLE handle, const unsigned char* cmd_byt
                 else
                 {
                     // check the Ack
-                    uint32_t ack_cmd;
-                    if (read_sync_cmd(handle, &ack_cmd) != 0 || ack_cmd != 0)
+                    if ( !is_ack_ok(handle) )
                     {
                         LogError("Failure reading TRM ack");
                         result = __FAILURE__;

--- a/tests/tpm_codec_ut/tpm_codec_ut.c
+++ b/tests/tpm_codec_ut/tpm_codec_ut.c
@@ -818,4 +818,67 @@ BEGIN_TEST_SUITE(tpm_codec_ut)
         //cleanup
     }
 
+    TEST_FUNCTION(ToTpmaObject_success)
+    {
+        //arrange
+        UINT32 attrs_all = FixedTPM | StClear | FixedParent | SensitiveDataOrigin | UserWithAuth | AdminWithPolicy | NoDA | EncryptedDuplication | Restricted | Decrypt | Sign | Encrypt;
+        UINT32 attrs_low = FixedTPM | StClear | FixedParent | SensitiveDataOrigin | UserWithAuth | AdminWithPolicy | NoDA | EncryptedDuplication;
+        UINT32 attrs_high = Restricted | Decrypt | Sign | Encrypt;
+        UINT32 attrs_none = 0;
+        //act
+        TPMA_OBJECT obj_all = ToTpmaObject(attrs_all);
+        TPMA_OBJECT obj_low = ToTpmaObject(attrs_low);
+        TPMA_OBJECT obj_high = ToTpmaObject(attrs_high);
+        TPMA_OBJECT obj_none = ToTpmaObject(attrs_none);
+        //assert
+        ASSERT_IS_TRUE(obj_all.fixedTPM);
+        ASSERT_IS_TRUE(obj_all.stClear);
+        ASSERT_IS_TRUE(obj_all.fixedParent);
+        ASSERT_IS_TRUE(obj_all.sensitiveDataOrigin);
+        ASSERT_IS_TRUE(obj_all.userWithAuth);
+        ASSERT_IS_TRUE(obj_all.adminWithPolicy);
+        ASSERT_IS_TRUE(obj_all.noDA);
+        ASSERT_IS_TRUE(obj_all.encryptedDuplication);
+        ASSERT_IS_TRUE(obj_all.restricted);
+        ASSERT_IS_TRUE(obj_all.decrypt);
+        ASSERT_IS_TRUE(obj_all.sign);
+
+        ASSERT_IS_TRUE(obj_low.fixedTPM);
+        ASSERT_IS_TRUE(obj_low.stClear);
+        ASSERT_IS_TRUE(obj_low.fixedParent);
+        ASSERT_IS_TRUE(obj_low.sensitiveDataOrigin);
+        ASSERT_IS_TRUE(obj_low.userWithAuth);
+        ASSERT_IS_TRUE(obj_low.adminWithPolicy);
+        ASSERT_IS_TRUE(obj_low.noDA);
+        ASSERT_IS_TRUE(obj_low.encryptedDuplication);
+        ASSERT_IS_FALSE(obj_low.restricted);
+        ASSERT_IS_FALSE(obj_low.decrypt);
+        ASSERT_IS_FALSE(obj_low.sign);
+
+        ASSERT_IS_FALSE(obj_high.fixedTPM);
+        ASSERT_IS_FALSE(obj_high.stClear);
+        ASSERT_IS_FALSE(obj_high.fixedParent);
+        ASSERT_IS_FALSE(obj_high.sensitiveDataOrigin);
+        ASSERT_IS_FALSE(obj_high.userWithAuth);
+        ASSERT_IS_FALSE(obj_high.adminWithPolicy);
+        ASSERT_IS_FALSE(obj_high.noDA);
+        ASSERT_IS_FALSE(obj_high.encryptedDuplication);
+        ASSERT_IS_TRUE(obj_high.restricted);
+        ASSERT_IS_TRUE(obj_high.decrypt);
+        ASSERT_IS_TRUE(obj_high.sign);
+        
+        ASSERT_IS_FALSE(obj_none.fixedTPM);
+        ASSERT_IS_FALSE(obj_none.stClear);
+        ASSERT_IS_FALSE(obj_none.fixedParent);
+        ASSERT_IS_FALSE(obj_none.sensitiveDataOrigin);
+        ASSERT_IS_FALSE(obj_none.userWithAuth);
+        ASSERT_IS_FALSE(obj_none.adminWithPolicy);
+        ASSERT_IS_FALSE(obj_none.noDA);
+        ASSERT_IS_FALSE(obj_none.encryptedDuplication);
+        ASSERT_IS_FALSE(obj_none.restricted);
+        ASSERT_IS_FALSE(obj_none.decrypt);
+        ASSERT_IS_FALSE(obj_none.sign);
+        //cleanup
+    }
+
 END_TEST_SUITE(tpm_codec_ut)


### PR DESCRIPTION
Removed "type-punning" warning in tpm_codec.c
Removed "function not used" warning in tpm_comm_linux.c
Added unit test to ensure I didn't break the "ToTpmaObject" function.