### PR TITLE
Remove TEST_INITIALIZE_MEMORY_DEBUG as they are useless

### DIFF
--- a/tests/tpm_codec_ut/tpm_codec_ut.c
+++ b/tests/tpm_codec_ut/tpm_codec_ut.c
@@ -95,7 +95,6 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(tpm_codec_ut)
 
@@ -103,7 +102,6 @@ BEGIN_TEST_SUITE(tpm_codec_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -138,7 +136,6 @@ BEGIN_TEST_SUITE(tpm_codec_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)

--- a/tests/tpm_comm_emulator_ut/tpm_comm_emulator_ut.c
+++ b/tests/tpm_comm_emulator_ut/tpm_comm_emulator_ut.c
@@ -120,7 +120,6 @@ static void my_tpm_socket_destroy(TPM_SOCKET_HANDLE handle)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(tpm_comm_emulator_ut)
 
@@ -128,7 +127,6 @@ BEGIN_TEST_SUITE(tpm_comm_emulator_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -166,7 +164,6 @@ BEGIN_TEST_SUITE(tpm_comm_emulator_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)

--- a/tests/tpm_comm_linux_ut/tpm_comm_linux_ut.c
+++ b/tests/tpm_comm_linux_ut/tpm_comm_linux_ut.c
@@ -71,7 +71,6 @@ static void my_tpm_socket_destroy(TPM_SOCKET_HANDLE handle)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(tpm_comm_linux_ut)
 
@@ -79,7 +78,6 @@ BEGIN_TEST_SUITE(tpm_comm_linux_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -118,7 +116,6 @@ BEGIN_TEST_SUITE(tpm_comm_linux_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)

--- a/tests/tpm_comm_win32_ut/tpm_comm_win32_ut.c
+++ b/tests/tpm_comm_win32_ut/tpm_comm_win32_ut.c
@@ -90,7 +90,6 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(tpm_comm_win32_ut)
 
@@ -98,7 +97,6 @@ BEGIN_TEST_SUITE(tpm_comm_win32_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -138,7 +136,6 @@ BEGIN_TEST_SUITE(tpm_comm_win32_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)

--- a/tests/tpm_memory_ut/tpm_memory_ut.c
+++ b/tests/tpm_memory_ut/tpm_memory_ut.c
@@ -65,7 +65,6 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(tpm_memory_ut)
 
@@ -73,7 +72,6 @@ BEGIN_TEST_SUITE(tpm_memory_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -96,7 +94,6 @@ BEGIN_TEST_SUITE(tpm_memory_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)


### PR DESCRIPTION
Remove TEST_INITIALIZE_MEMORY_DEBUG as they are useless